### PR TITLE
allow interpolation of min-date/max-date and default-date

### DIFF
--- a/pikaday-angular.js
+++ b/pikaday-angular.js
@@ -27,9 +27,9 @@
         config = configs;
       };
     })
-    .directive('pikaday', ['pikadayConfig', pikadayDirectiveFn]);
+    .directive('pikaday', ['pikadayConfig', '$interpolate', pikadayDirectiveFn]);
 
-  function pikadayDirectiveFn(pikadayConfig) {
+  function pikadayDirectiveFn(pikadayConfig, $interpolate) {
 
     return {
 
@@ -110,9 +110,13 @@
 
             case "minDate":
             case "maxDate":
+
+              config[attr] = new Date($interpolate(value)(scope));
+              break;
+
             case "defaultDate":
 
-              config[attr] = new Date(value);
+              config[attr] = $interpolate(value)(scope);
               break;
 
             // Elements

--- a/test/coercion_test.js
+++ b/test/coercion_test.js
@@ -4,6 +4,26 @@ describe('directive: pikaday', function() {
 
   // INLINE
 
+  describe('default-date', function(){
+	  var parse;
+	  beforeEach(inject(function($rootScope, $compile) {
+
+	    parse = function (html){
+		  var scope    = $rootScope.$new();
+		  element  = angular.element(html);
+
+		  compiled = $compile(element)(scope);
+		  scope.$digest();
+		  return scope;
+	    }
+      }));
+
+	  it('evaluates an expression when setting default-date', function(){
+		var scope = parse('<input pikaday="myPickerObject" default-date="{{\'2008-01-25\'}}">')
+		assert.deepEqual(scope.myPickerObject._o.defaultDate, '2008-01-25');
+	  });
+  });
+
   describe('inline', function() {
 
     var element, scope;
@@ -44,6 +64,7 @@ describe('directive: pikaday', function() {
 
       compiled = $compile(element)(scope);
       scope.$digest();
+
 
     }));
 
@@ -118,7 +139,7 @@ describe('directive: pikaday', function() {
       });
 
       it("should apply default-date ", function() {
-        assert.deepEqual(scope.myPickerObject._o.defaultDate.getTime(), 884304000000);
+        assert.deepEqual(scope.myPickerObject._o.defaultDate, "01/09/1998");
       });
 
       // it("should provide the trigger element", function() {


### PR DESCRIPTION
This allows `default-date`, `min-date` and `max-date` to be interpolated, as in:

    <input pickaday="myDatePicker" default-date="{{someDate}}">

Where `someDate` is defined in the controller somewhere:

    $scope.someDate = '1999-12-31';

We also pass `default-date` as a string through to pikaday.js so it can be formatted using `Date.parse(...)`, not `new Date(...)`, which is much more restrictive for parsing dates, and therefore more reliable.